### PR TITLE
Fixed Dockerfile and Updated README

### DIFF
--- a/examples/chatgpt/Dockerfile
+++ b/examples/chatgpt/Dockerfile
@@ -35,10 +35,15 @@ RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt
 # Use the customised robot JAR file containing the modified HTML
 
 USER jenkins
-COPY robot.jar /var/jenkins_home/plugins/robot/WEB-INF/lib
+
+# Since the persistent storage mounted from the host takes precedent,
+# copy any jar files there instead of into the container image.
+# COPY robot.jar /var/jenkins_home/plugins/robot/WEB-INF/lib
 
 USER root
 
+COPY jenkins.sh /usr/local/bin
+RUN chmod 755 /usr/local/bin/jenkins.sh
 RUN chown -R jenkins:jenkins /var/jenkins_home/init.groovy.d/
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yqq apt-utils git-core curl libssl-dev build-essential libssl-dev libffi-dev python3-dev python3-yaml python3-pip \


### PR DESCRIPTION
Fixed the Dockerfile to copy `jenkins.sh` and rewrote the README to mention persistent volumes and replace `/var/jenkins_home` with `/mnt/data`.