### PR TITLE
Junos-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,61 @@ Environment Variable | Default Value | Meaning
 ``KEYPASS`` | ``nita123`` | Passkey used to create self-signed Jenkins keys
 ``KUBEROOT`` | ``/etc/kubernetes`` | System location for Kubernetes configuration
 ``KUBECONFIG`` | ``$KUBEROOT/admin.conf`` | Location of user's Kubernetes configuration
+``JUNOS_MCP_DEVICES`` | ``$NITAROOT/nita/examples/mcp/devices.json`` | Default device mapping file for optional Junos MCP server pod
+``JUNOS_MCP_REPO`` | ``$NITAROOT/junos-mcp-server`` | Location to clone Junos MCP server repository for local image build
 ``DEBUG`` | unset | Set it to true in the parent shell, to see additional output
 ``IGNORE_WARNINGS`` | unset | Set it to true in the parent shell if you want to install NITA and ignore any important warnings
+
+## Optional: Junos MCP Server
+
+NITA can optionally install a [Junos Model Context Protocol (MCP) server](https://github.com/Juniper/junos-mcp-server) as a Kubernetes pod that runs on port 8090. This MCP server provides a bridge between LLM-compatible clients (such as Claude Desktop or VSCode with GitHub Copilot) and Juniper Junos network devices.
+
+During the ``install.sh`` execution, you will be prompted:
+
+```
+Install Junos MCP server pod on port 8090 (y|n|q)? [y]
+```
+
+If you answer ``Y``, the installer will:
+
+1. Clone the Junos MCP server repository from GitHub to ``$JUNOS_MCP_REPO`` (default: ``/opt/junos-mcp-server``)
+2. Build a local Docker image named ``junos-mcp-server:local``
+3. Import the image into Kubernetes' containerd runtime
+4. Create a ConfigMap from the default device mapping file at ``$JUNOS_MCP_DEVICES`` (default: ``/opt/nita/examples/mcp/devices.json``)
+5. Deploy the MCP server pod and service in the ``nita`` namespace, listening on port 8090
+
+### Default Device List
+
+The Junos MCP server uses a default device list located at ``examples/mcp/devices.json``. This file contains sample device configurations that the MCP server can interact with. You can customize this list by:
+
+- Editing the file directly before installation
+- Providing an alternative file path via the ``JUNOS_MCP_DEVICES`` environment variable
+- Updating the ConfigMap after installation using:
+  ```
+  kubectl delete cm junos-mcp-devices-cm -n nita
+  kubectl create cm junos-mcp-devices-cm --from-file=devices.json=/path/to/your/devices.json -n nita
+  kubectl rollout restart deploy/junos-mcp -n nita
+  ```
+
+### Verifying the MCP Server
+
+After installation, verify that the Junos MCP server is running:
+
+```
+# Check deployment status
+kubectl -n nita get deploy junos-mcp -o wide
+
+# Check pod status
+kubectl -n nita get pods -l app=junos-mcp -o wide
+
+# Check service endpoint (accessible on node IP port 8090)
+kubectl -n nita get svc junos-mcp -o wide
+
+# View server logs
+kubectl -n nita logs deploy/junos-mcp --tail=100
+```
+
+The MCP server will be accessible at ``http://<node-ip>:8090/mcp/`` from any client on the network.
 
 # History
 

--- a/examples/mcp/devices.json
+++ b/examples/mcp/devices.json
@@ -1,0 +1,218 @@
+{
+    "dc1-borderleaf1": {
+        "ip": "100.123.24.1",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc1-firewall1": {
+        "ip": "100.123.26.1",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc1-webserver": {
+        "ip": "100.123.20.1",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "wan-pe1": {
+        "ip": "100.123.1.0",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc1-appserver": {
+        "ip": "100.123.20.2",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc1-borderleaf2": {
+        "ip": "100.123.24.2",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc1-firewall2": {
+        "ip": "100.123.26.2",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "wan-pe2": {
+        "ip": "100.123.1.1",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc1-dbserver": {
+        "ip": "100.123.20.3",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc1-spine1": {
+        "ip": "100.123.24.3",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc2-firewall1": {
+        "ip": "100.123.26.3",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc1-spine2": {
+        "ip": "100.123.24.4",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc2-firewall2": {
+        "ip": "100.123.26.4",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc2-webserver1": {
+        "ip": "100.123.20.4",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc1-leaf1": {
+        "ip": "100.123.24.5",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc2-webserver2": {
+        "ip": "100.123.20.5",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc1-leaf2": {
+        "ip": "100.123.24.6",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc1-leaf3": {
+        "ip": "100.123.24.7",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc2-spine1": {
+        "ip": "100.123.24.8",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "dc2-spine2": {
+        "ip": "100.123.24.9",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "HelperVM": {
+        "ip": "100.123.0.8",
+        "port": 22,
+        "username": "root",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "IntGwy": {
+        "ip": "100.123.41.1",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "NITA": {
+        "ip": "100.123.0.16",
+        "port": 22,
+        "username": "jcluser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    },
+    "vLinuxSRV-A1": {
+        "ip": "100.123.42.1",
+        "port": 22,
+        "username": "labuser",
+        "auth": {
+            "type": "password",
+            "password": "Juniper!1"
+        }
+    }
+}

--- a/examples/mcp/devices.json
+++ b/examples/mcp/devices.json
@@ -5,7 +5,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc1-firewall1": {
@@ -14,7 +14,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc1-webserver": {
@@ -23,7 +23,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "wan-pe1": {
@@ -32,7 +32,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc1-appserver": {
@@ -41,7 +41,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc1-borderleaf2": {
@@ -50,7 +50,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc1-firewall2": {
@@ -59,7 +59,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "wan-pe2": {
@@ -68,7 +68,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc1-dbserver": {
@@ -77,7 +77,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc1-spine1": {
@@ -86,7 +86,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc2-firewall1": {
@@ -95,7 +95,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc1-spine2": {
@@ -104,7 +104,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc2-firewall2": {
@@ -113,7 +113,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc2-webserver1": {
@@ -122,7 +122,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc1-leaf1": {
@@ -131,7 +131,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc2-webserver2": {
@@ -140,7 +140,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc1-leaf2": {
@@ -149,7 +149,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc1-leaf3": {
@@ -158,7 +158,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc2-spine1": {
@@ -167,7 +167,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "dc2-spine2": {
@@ -176,7 +176,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "HelperVM": {
@@ -185,7 +185,7 @@
         "username": "root",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "IntGwy": {
@@ -194,7 +194,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "NITA": {
@@ -203,7 +203,7 @@
         "username": "jcluser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     },
     "vLinuxSRV-A1": {
@@ -212,7 +212,7 @@
         "username": "labuser",
         "auth": {
             "type": "password",
-            "password": "Juniper!1"
+            "password": "Password"
         }
     }
 }

--- a/install.sh
+++ b/install.sh
@@ -33,6 +33,10 @@ K8SROOT=${K8SROOT:=$NITAROOT/nita/k8s}
 PROXY=${PROXY:=$K8SROOT/proxy}
 CERTS=${CERTS:=$PROXY/certificates}
 JENKINS=${JENKINS:=/var/jenkins_home}
+JUNOS_MCP_DEVICES=${JUNOS_MCP_DEVICES:=$NITAROOT/nita/examples/mcp/devices.json}
+JUNOS_MCP_REPO=${JUNOS_MCP_REPO:=$NITAROOT/junos-mcp-server}
+JUNOS_MCP_IMAGE=${JUNOS_MCP_IMAGE:=junos-mcp-server:local}
+JUNOS_MCP_IMAGE_ARCHIVE=${JUNOS_MCP_IMAGE_ARCHIVE:=/tmp/junos-mcp-server-local.tar}
 KEYPASS=${KEYPASS:="nita123"}
 
 KUBEROOT=${KUBEROOT:=/etc/kubernetes}
@@ -40,7 +44,7 @@ KUBECONFIG=${KUBECONFIG:=$KUBEROOT/admin.conf}
 
 PATH=${PATH}:${JAVA_HOME}/bin
 export OWNER_HOME=`egrep "^${REALUSER}" /etc/passwd | awk -F: '{print $6}'`
-export PATH NITAROOT KUBEROOT K8SROOT PROXY CERTS JENKINS KEYPASS KUBECONFIG JAVA_HOME
+export PATH NITAROOT KUBEROOT K8SROOT PROXY CERTS JENKINS JUNOS_MCP_DEVICES JUNOS_MCP_REPO JUNOS_MCP_IMAGE JUNOS_MCP_IMAGE_ARCHIVE KEYPASS KUBECONFIG JAVA_HOME
 
 ANSIBLE_IMAGE="ghcr.io/juniper/nita-ansible:latest"
 ROBOT_IMAGE="ghcr.io/juniper/nita-robot:latest"
@@ -435,6 +439,43 @@ Question "Install NITA repositories" && {
     echo "export KUBECONFIG=${OWNER_HOME}/.kube/config" >> ${OWNER_HOME}/.bashrc
 
     echo "${ME}: Now ${bold}source your bashrc file${normal} to set KUBECONFIG in your shell"
+
+    Question "Install Junos MCP server pod on port 8090" && {
+
+        if [ ! -f "${JUNOS_MCP_DEVICES}" ]; then
+            echo "${ME}: Error: Cannot find default devices mapping file: ${JUNOS_MCP_DEVICES}"
+            echo "${ME}: Skipping Junos MCP server install."
+        else
+
+            if [ ! -d "${JUNOS_MCP_REPO}" ]; then
+                echo "${ME}: Cloning Junos MCP server repository to ${JUNOS_MCP_REPO}"
+                git clone https://github.com/Juniper/junos-mcp-server.git ${JUNOS_MCP_REPO}
+            else
+                echo "${ME}: Found existing Junos MCP repo at ${JUNOS_MCP_REPO}"
+            fi
+
+            echo "${ME}: Building local Junos MCP image ${JUNOS_MCP_IMAGE}"
+            docker build -t ${JUNOS_MCP_IMAGE} ${JUNOS_MCP_REPO}
+
+            echo "${ME}: Exporting image archive ${JUNOS_MCP_IMAGE_ARCHIVE}"
+            rm -f ${JUNOS_MCP_IMAGE_ARCHIVE}
+            docker save ${JUNOS_MCP_IMAGE} -o ${JUNOS_MCP_IMAGE_ARCHIVE}
+
+            echo "${ME}: Importing image into containerd for Kubernetes"
+            ctr -n k8s.io images import ${JUNOS_MCP_IMAGE_ARCHIVE}
+
+            echo "${ME}: Creating/refreshing Junos MCP devices config map from ${JUNOS_MCP_DEVICES}"
+            kubectl delete cm junos-mcp-devices-cm --namespace nita --ignore-not-found
+            kubectl create cm junos-mcp-devices-cm --from-file=devices.json=${JUNOS_MCP_DEVICES} --namespace nita
+
+            echo "${ME}: Applying Junos MCP server deployment and service"
+            kubectl apply -f ${K8SROOT}/junos-mcp-deployment.yaml
+            kubectl apply -f ${K8SROOT}/junos-mcp-service.yaml
+
+            echo "${ME}: Junos MCP server pod requested. Service endpoint is available on port 8090 inside namespace nita."
+
+        fi
+    }
 
 }
 

--- a/install.sh
+++ b/install.sh
@@ -440,44 +440,68 @@ Question "Install NITA repositories" && {
 
     echo "${ME}: Now ${bold}source your bashrc file${normal} to set KUBECONFIG in your shell"
 
-    Question "Install Junos MCP server pod on port 8090" && {
+}
 
-        if [ ! -f "${JUNOS_MCP_DEVICES}" ]; then
-            echo "${ME}: Error: Cannot find default devices mapping file: ${JUNOS_MCP_DEVICES}"
-            echo "${ME}: Skipping Junos MCP server install."
-        else
+# ------------------------------------------------------------------------------
 
-            if [ ! -d "${JUNOS_MCP_REPO}" ]; then
-                echo "${ME}: Cloning Junos MCP server repository to ${JUNOS_MCP_REPO}"
-                git clone https://github.com/Juniper/junos-mcp-server.git ${JUNOS_MCP_REPO}
-            else
-                echo "${ME}: Found existing Junos MCP repo at ${JUNOS_MCP_REPO}"
-            fi
+Question "Install Junos MCP server pod on port 8090" && {
 
-            echo "${ME}: Building local Junos MCP image ${JUNOS_MCP_IMAGE}"
-            docker build -t ${JUNOS_MCP_IMAGE} ${JUNOS_MCP_REPO}
+    LOCAL_SCRIPT_DIR="$(dirname $(realpath $0))"
 
-            echo "${ME}: Exporting image archive ${JUNOS_MCP_IMAGE_ARCHIVE}"
-            rm -f ${JUNOS_MCP_IMAGE_ARCHIVE}
-            docker save ${JUNOS_MCP_IMAGE} -o ${JUNOS_MCP_IMAGE_ARCHIVE}
+    # If the devices file isn't at the install target yet, seed it from the local repo copy
+    LOCAL_MCP_DEVICES="${LOCAL_SCRIPT_DIR}/examples/mcp/devices.json"
+    if [ ! -f "${JUNOS_MCP_DEVICES}" ] && [ -f "${LOCAL_MCP_DEVICES}" ]; then
+        echo "${ME}: Seeding devices file from local repo to ${JUNOS_MCP_DEVICES}"
+        mkdir -p "$(dirname ${JUNOS_MCP_DEVICES})"
+        cp "${LOCAL_MCP_DEVICES}" "${JUNOS_MCP_DEVICES}"
+    fi
 
-            echo "${ME}: Importing image into containerd for Kubernetes"
-            ctr -n k8s.io images import ${JUNOS_MCP_IMAGE_ARCHIVE}
-
-            echo "${ME}: Creating/refreshing Junos MCP devices config map from ${JUNOS_MCP_DEVICES}"
-            kubectl delete cm junos-mcp-devices-cm --namespace nita --ignore-not-found
-            kubectl create cm junos-mcp-devices-cm --from-file=devices.json=${JUNOS_MCP_DEVICES} --namespace nita
-
-            echo "${ME}: Applying Junos MCP server deployment and service"
-            kubectl apply -f ${K8SROOT}/junos-mcp-deployment.yaml
-            kubectl apply -f ${K8SROOT}/junos-mcp-service.yaml
-
-            echo "${ME}: Junos MCP server pod requested. Service endpoint is available on port 8090 inside namespace nita."
-
+    # If the k8s YAMLs aren't at the install target yet, copy them from the local repo
+    for YAML in junos-mcp-deployment.yaml junos-mcp-service.yaml; do
+        if [ ! -f "${K8SROOT}/${YAML}" ] && [ -f "${LOCAL_SCRIPT_DIR}/k8s/${YAML}" ]; then
+            echo "${ME}: Copying ${YAML} to ${K8SROOT}/"
+            mkdir -p "${K8SROOT}"
+            cp "${LOCAL_SCRIPT_DIR}/k8s/${YAML}" "${K8SROOT}/${YAML}"
         fi
-    }
+    done
+
+    if [ ! -f "${JUNOS_MCP_DEVICES}" ]; then
+        echo "${ME}: Error: Cannot find default devices mapping file: ${JUNOS_MCP_DEVICES}"
+        echo "${ME}: Skipping Junos MCP server install."
+    else
+
+        if [ ! -d "${JUNOS_MCP_REPO}" ]; then
+            echo "${ME}: Cloning Junos MCP server repository to ${JUNOS_MCP_REPO}"
+            git clone https://github.com/Juniper/junos-mcp-server.git ${JUNOS_MCP_REPO}
+        else
+            echo "${ME}: Found existing Junos MCP repo at ${JUNOS_MCP_REPO}"
+        fi
+
+        echo "${ME}: Building local Junos MCP image ${JUNOS_MCP_IMAGE}"
+        docker build -t ${JUNOS_MCP_IMAGE} ${JUNOS_MCP_REPO}
+
+        echo "${ME}: Exporting image archive ${JUNOS_MCP_IMAGE_ARCHIVE}"
+        rm -f ${JUNOS_MCP_IMAGE_ARCHIVE}
+        docker save ${JUNOS_MCP_IMAGE} -o ${JUNOS_MCP_IMAGE_ARCHIVE}
+
+        echo "${ME}: Importing image into containerd for Kubernetes"
+        ctr -n k8s.io images import ${JUNOS_MCP_IMAGE_ARCHIVE}
+
+        echo "${ME}: Creating/refreshing Junos MCP devices config map from ${JUNOS_MCP_DEVICES}"
+        kubectl delete cm junos-mcp-devices-cm --namespace nita --ignore-not-found
+        kubectl create cm junos-mcp-devices-cm --from-file=devices.json=${JUNOS_MCP_DEVICES} --namespace nita
+
+        echo "${ME}: Applying Junos MCP server deployment and service"
+        kubectl apply -f ${K8SROOT}/junos-mcp-deployment.yaml
+        kubectl apply -f ${K8SROOT}/junos-mcp-service.yaml
+
+        echo "${ME}: Junos MCP server pod requested. Service endpoint is available on port 8090 inside namespace nita."
+
+    fi
 
 }
+
+# ------------------------------------------------------------------------------
 
 Question "Do you want to run Ansible as a standalone Docker container" && {
 

--- a/k8s/junos-mcp-deployment.yaml
+++ b/k8s/junos-mcp-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: nita
+  labels:
+    app: junos-mcp
+  name: junos-mcp
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: junos-mcp
+  template:
+    metadata:
+      labels:
+        app: junos-mcp
+    spec:
+      containers:
+        - name: junos-mcp
+          image: junos-mcp-server:local
+          imagePullPolicy: Never
+          command: ["python", "jmcp.py"]
+          args:
+            - "-f"
+            - "/app/config/devices.json"
+            - "-t"
+            - "streamable-http"
+            - "-H"
+            - "0.0.0.0"
+            - "-p"
+            - "8090"
+          ports:
+            - containerPort: 8090
+              hostPort: 8090
+              protocol: TCP
+          volumeMounts:
+            - name: devices-config
+              mountPath: /app/config/devices.json
+              subPath: devices.json
+      restartPolicy: Always
+      volumes:
+        - name: devices-config
+          configMap:
+            name: junos-mcp-devices-cm
+            items:
+              - key: devices.json
+                path: devices.json

--- a/k8s/junos-mcp-service.yaml
+++ b/k8s/junos-mcp-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: nita
+  labels:
+    app: junos-mcp
+  name: junos-mcp
+spec:
+  selector:
+    app: junos-mcp
+  ports:
+    - protocol: TCP
+      port: 8090
+      targetPort: 8090
+  type: ClusterIP


### PR DESCRIPTION
Added option to install.sh to allow user to download junos-mcp-server from [github](https://github.com/juniper/junos-mcp-server) and install it as k8s pod. Uses the examples/mcp/devices.json file as the base. Updated README as well. 