### PR TITLE
Fix Junos MCP deployment for AlmaLinux off-box access

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,10 @@ If you answer ``Y``, the installer will:
 2. Build a local Docker image named ``junos-mcp-server:local``
 3. Import the image into Kubernetes' containerd runtime
 4. Create a ConfigMap from the default device mapping file at ``$JUNOS_MCP_DEVICES`` (default: ``/opt/nita/examples/mcp/devices.json``)
-5. Deploy the MCP server pod and service in the ``nita`` namespace, listening on port 8090
+5. Generate an internal MCP token plus an nginx proxy config for lab/demo use
+6. Deploy the MCP server pod and service in the ``nita`` namespace, listening on port 8090
+
+For the packaged NITA lab/demo deployment, the MCP backend stays token-protected on loopback inside the pod and an nginx sidecar listens on port 8090, injecting the internal token on behalf of clients. This keeps the upstream MCP server in its supported authenticated mode while allowing off-box demo access without per-user token setup.
 
 ### Default Device List
 
@@ -117,9 +120,65 @@ kubectl -n nita get svc junos-mcp -o wide
 
 # View server logs
 kubectl -n nita logs deploy/junos-mcp --tail=100
+
+# View proxy logs
+kubectl -n nita logs deploy/junos-mcp -c junos-mcp-proxy --tail=100
 ```
 
 The MCP server will be accessible at ``http://<node-ip>:8090/mcp/`` from any client on the network.
+
+The upstream MCP server still enforces token authentication on its streamable HTTP transport. NITA hides that token behind the in-pod proxy for lab/demo installs. If you prefer explicit client authentication instead, replace the proxy flow with a mounted ``.tokens`` file and send ``Authorization: Bearer <token>`` from the client.
+
+### Refreshing MCP Auth And Proxy Resources
+
+If you change the device map, need to recreate the MCP proxy configuration, or want to force a known internal token for troubleshooting, you can refresh the Kubernetes resources manually:
+
+```
+export JMCP_TOKEN_ID=nita-lab
+export JMCP_TOKEN_VALUE="jmcp_change_me"
+
+cat >/tmp/junos-mcp-tokens.json <<EOF
+{
+  "${JMCP_TOKEN_ID}": {
+    "token": "${JMCP_TOKEN_VALUE}",
+    "description": "NITA lab/demo internal token",
+    "created": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  }
+}
+EOF
+
+cat >/tmp/junos-mcp-nginx.conf <<EOF
+server {
+    listen 8090;
+  location /mcp {
+    rewrite ^/mcp$ /mcp/ break;
+        proxy_pass http://127.0.0.1:8091;
+        proxy_http_version 1.1;
+        proxy_set_header Authorization "Bearer ${JMCP_TOKEN_VALUE}";
+      proxy_set_header Accept \$http_accept;
+      proxy_set_header Content-Type \$content_type;
+      proxy_set_header Host \$host;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 3600;
+    }
+}
+EOF
+
+kubectl -n nita delete secret junos-mcp-auth --ignore-not-found
+kubectl -n nita create secret generic junos-mcp-auth \
+  --from-file=.tokens=/tmp/junos-mcp-tokens.json
+
+kubectl -n nita delete cm junos-mcp-proxy-cm --ignore-not-found
+kubectl -n nita create cm junos-mcp-proxy-cm \
+  --from-file=default.conf=/tmp/junos-mcp-nginx.conf
+
+kubectl -n nita rollout restart deploy/junos-mcp
+kubectl -n nita rollout status deploy/junos-mcp
+```
+
+The internal token is only used by the in-pod nginx proxy. Off-box clients still connect to ``http://<node-ip>:8090/mcp/`` without sending any ``Authorization`` header.
 
 # History
 

--- a/install.sh
+++ b/install.sh
@@ -37,6 +37,8 @@ JUNOS_MCP_DEVICES=${JUNOS_MCP_DEVICES:=$NITAROOT/nita/examples/mcp/devices.json}
 JUNOS_MCP_REPO=${JUNOS_MCP_REPO:=$NITAROOT/junos-mcp-server}
 JUNOS_MCP_IMAGE=${JUNOS_MCP_IMAGE:=junos-mcp-server:local}
 JUNOS_MCP_IMAGE_ARCHIVE=${JUNOS_MCP_IMAGE_ARCHIVE:=/tmp/junos-mcp-server-local.tar}
+JUNOS_MCP_TOKEN_ID=${JUNOS_MCP_TOKEN_ID:=nita-lab}
+JUNOS_MCP_TOKEN_VALUE=${JUNOS_MCP_TOKEN_VALUE:=}
 KEYPASS=${KEYPASS:="nita123"}
 
 KUBEROOT=${KUBEROOT:=/etc/kubernetes}
@@ -44,7 +46,7 @@ KUBECONFIG=${KUBECONFIG:=$KUBEROOT/admin.conf}
 
 PATH=${PATH}:${JAVA_HOME}/bin
 export OWNER_HOME=`egrep "^${REALUSER}" /etc/passwd | awk -F: '{print $6}'`
-export PATH NITAROOT KUBEROOT K8SROOT PROXY CERTS JENKINS JUNOS_MCP_DEVICES JUNOS_MCP_REPO JUNOS_MCP_IMAGE JUNOS_MCP_IMAGE_ARCHIVE KEYPASS KUBECONFIG JAVA_HOME CONTAINER_REGISTRY GITHUB_ORG NITA_ANSIBLE_IMAGE NITA_ROBOT_IMAGE
+export PATH NITAROOT KUBEROOT K8SROOT PROXY CERTS JENKINS JUNOS_MCP_DEVICES JUNOS_MCP_REPO JUNOS_MCP_IMAGE JUNOS_MCP_IMAGE_ARCHIVE JUNOS_MCP_TOKEN_ID JUNOS_MCP_TOKEN_VALUE KEYPASS KUBECONFIG JAVA_HOME CONTAINER_REGISTRY GITHUB_ORG NITA_ANSIBLE_IMAGE NITA_ROBOT_IMAGE
 
 CONTAINER_REGISTRY=${CONTAINER_REGISTRY:=ghcr.io/juniper}
 GITHUB_ORG=${GITHUB_ORG:=Juniper}
@@ -535,11 +537,58 @@ Question "Install Junos MCP server pod on port 8090" && {
         kubectl delete cm junos-mcp-devices-cm --namespace nita --ignore-not-found
         kubectl create cm junos-mcp-devices-cm --from-file=devices.json=${JUNOS_MCP_DEVICES} --namespace nita
 
+        if [ -z "${JUNOS_MCP_TOKEN_VALUE}" ]; then
+            if [ -x "$(command -v openssl)" ]; then
+                JUNOS_MCP_TOKEN_VALUE="jmcp_$(openssl rand -hex 24)"
+            else
+                JUNOS_MCP_TOKEN_VALUE="jmcp_$(date +%s)_${RANDOM}${RANDOM}"
+            fi
+        fi
+
+        JUNOS_MCP_TOKEN_FILE=$(mktemp /tmp/junos-mcp-tokens.XXXXXX)
+        JUNOS_MCP_PROXY_CONF=$(mktemp /tmp/junos-mcp-nginx.XXXXXX)
+
+        cat > ${JUNOS_MCP_TOKEN_FILE} <<EOF
+{
+  "${JUNOS_MCP_TOKEN_ID}": {
+    "token": "${JUNOS_MCP_TOKEN_VALUE}",
+    "description": "NITA lab/demo internal token",
+    "created": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  }
+}
+EOF
+
+        cat > ${JUNOS_MCP_PROXY_CONF} <<EOF
+server {
+    listen 8090;
+    location /mcp {
+        rewrite ^/mcp$ /mcp/ break;
+        proxy_pass http://127.0.0.1:8091;
+        proxy_http_version 1.1;
+        proxy_set_header Authorization "Bearer ${JUNOS_MCP_TOKEN_VALUE}";
+        proxy_set_header Accept \$http_accept;
+        proxy_set_header Content-Type \$content_type;
+        proxy_set_header Host \$host;
+        proxy_set_header Connection "";
+        proxy_buffering off;
+        proxy_request_buffering off;
+        proxy_read_timeout 3600;
+    }
+}
+EOF
+
+        echo "${ME}: Creating/refreshing Junos MCP authentication secret and proxy config"
+        kubectl delete secret junos-mcp-auth --namespace nita --ignore-not-found
+        kubectl create secret generic junos-mcp-auth --from-file=.tokens=${JUNOS_MCP_TOKEN_FILE} --namespace nita
+        kubectl delete cm junos-mcp-proxy-cm --namespace nita --ignore-not-found
+        kubectl create cm junos-mcp-proxy-cm --from-file=default.conf=${JUNOS_MCP_PROXY_CONF} --namespace nita
+        rm -f ${JUNOS_MCP_TOKEN_FILE} ${JUNOS_MCP_PROXY_CONF}
+
         echo "${ME}: Applying Junos MCP server deployment and service"
         kubectl apply -f ${K8SROOT}/junos-mcp-deployment.yaml
         kubectl apply -f ${K8SROOT}/junos-mcp-service.yaml
 
-        echo "${ME}: Junos MCP server pod requested. Service endpoint is available on port 8090 inside namespace nita."
+        echo "${ME}: Junos MCP server pod requested. Service endpoint is available on port 8090 inside namespace nita and on the node IP for unauthenticated lab/demo access."
 
         fi
 

--- a/k8s/junos-mcp-deployment.yaml
+++ b/k8s/junos-mcp-deployment.yaml
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       app: junos-mcp
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:
@@ -26,17 +28,37 @@ spec:
             - "-t"
             - "streamable-http"
             - "-H"
-            - "0.0.0.0"
+            - "127.0.0.1"
             - "-p"
-            - "8090"
+            - "8091"
+          ports:
+            - containerPort: 8091
+              protocol: TCP
+          readinessProbe:
+            exec:
+              command:
+                - python
+                - -c
+                - import socket; socket.create_connection(("127.0.0.1", 8091), 1).close()
+            initialDelaySeconds: 2
+            periodSeconds: 2
+          volumeMounts:
+            - name: devices-config
+              mountPath: /app/config/devices.json
+              subPath: devices.json
+            - name: auth-tokens
+              mountPath: /app/.tokens
+              subPath: .tokens
+        - name: junos-mcp-proxy
+          image: nginx:stable
           ports:
             - containerPort: 8090
               hostPort: 8090
               protocol: TCP
           volumeMounts:
-            - name: devices-config
-              mountPath: /app/config/devices.json
-              subPath: devices.json
+            - name: proxy-config
+              mountPath: /etc/nginx/conf.d/default.conf
+              subPath: default.conf
       restartPolicy: Always
       volumes:
         - name: devices-config
@@ -45,3 +67,15 @@ spec:
             items:
               - key: devices.json
                 path: devices.json
+        - name: auth-tokens
+          secret:
+            secretName: junos-mcp-auth
+            items:
+              - key: .tokens
+                path: .tokens
+        - name: proxy-config
+          configMap:
+            name: junos-mcp-proxy-cm
+            items:
+              - key: default.conf
+                path: default.conf


### PR DESCRIPTION
Fixes a couple issues with running MCP as a pod on Alma linux (or perhaps more recent system files than are available on the old Ubuntu build)