### PR TITLE
feat(kube): add `nita-cmd kube renew-certs` command for Kubernetes ce…

### DIFF
--- a/cli_scripts/nita-cmd_kube_renew-certs
+++ b/cli_scripts/nita-cmd_kube_renew-certs
@@ -1,0 +1,35 @@
+#!/bin/bash
+# ********************************************************
+#
+# Project: nita
+#
+# Copyright (c) Juniper Networks, Inc., 2024. All rights reserved.
+#
+# Notice and Disclaimer: This code is licensed to you under the Apache 2.0 License (the "License"). You may not use this code except in compliance with the License. This code is not an official Juniper product. You can obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.html
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Third-Party Code: This code may depend on other components under separate copyright notice and license terms. Your use of the source code for those components is subject to the terms and conditions of the respective license as noted in the Third-Party source code file.
+#
+# ********************************************************
+
+# Priority order is top down
+
+if [ -x "$(command -v kubeadm)" ] && [ -x "$(command -v systemctl)" ]; then
+
+    CMD="kubeadm certs renew all && systemctl restart kubelet"
+
+elif [ -x "$(command -v kubeadm)" ]; then
+
+    CMD="kubeadm certs renew all"
+
+else
+
+  echo 'Error: unsupported command. kubeadm is required to renew Kubernetes certificates.' >&2
+  exit 1
+
+fi
+
+[ ${_CLI_RUNNER_DEBUG} ] && echo ${CMD}>&2
+
+eval "${CMD}"

--- a/cli_scripts/nita-cmd_kube_renew-certs_help
+++ b/cli_scripts/nita-cmd_kube_renew-certs_help
@@ -1,0 +1,18 @@
+#!/bin/bash
+# ********************************************************
+#
+# Project: nita
+#
+# Copyright (c) Juniper Networks, Inc., 2024. All rights reserved.
+#
+# Notice and Disclaimer: This code is licensed to you under the Apache 2.0 License (the "License"). You may not use this code except in compliance with the License. This code is not an official Juniper product. You can obtain a copy of the License at https://www.apache.org/licenses/LICENSE-2.0.html
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Third-Party Code: This code may depend on other components under separate copyright notice and license terms. Your use of the source code for those components is subject to the terms and conditions of the respective license as noted in the Third-Party source code file.
+#
+# ********************************************************
+        echo -n "    nita-cmd kube renew-certs => "
+        echo `cat <<EOT
+Renew Kubernetes certs (kubeadm) and restart kubelet when systemctl is available.
+EOT` >&2

--- a/docs/certificates.md
+++ b/docs/certificates.md
@@ -17,6 +17,15 @@ $ sudo kubeadm certs renew all
 $ sudo systemctl restart kubelet
 ```
 
+You can also use NITA CLI to run this flow:
+
+```
+$ sudo nita-cmd kube renew-certs
+```
+
+This command uses `kubeadm certs renew all` and then restarts `kubelet` when
+`systemctl` is available.
+
 :warning: Be aware that the 1-year duration for Kubernetes certificates seems to be hardcoded in the `kubeadm` command, so you will need to remember to renew them on an annual basis.
 
 ## Zscaler, Certificates and K8S

--- a/docs/nita-cmd.md
+++ b/docs/nita-cmd.md
@@ -58,6 +58,19 @@ $ nita-cmd containers help
 
 This example shows that it is possible to see the list of all running Docker containers and the versions of all of those containers. Typing ``nita-cmd containers list`` is much easier than having to remember the full Docker command that you need to type!
 
+## Kubernetes Certificate Renewal
+
+For kubeadm-managed Kubernetes deployments, certificate renewal can be run with:
+
+```shell
+$ sudo nita-cmd kube renew-certs
+```
+
+This command runs ``kubeadm certs renew all`` and restarts ``kubelet`` when
+``systemctl`` is available.
+
+If ``kubeadm`` is not installed, the command exits with an error.
+
 # CREATING YOUR OWN COMMAND
 
 Because the ``nita-cmd`` script is actually a wrapper for executing other scripts, its functionality can easily be extended just be adding new scripts for it to execute. You do this by prefixing the name of your new executable shell script with ``nita-cmd_`` and storing it in the directory ``/usr/local/bin``. You can also add multiple levels to the command simply by creating multiple scripts with underscores between each argument in the filename.
@@ -72,7 +85,7 @@ Given that ``/usr/local/bin`` is owned by root, we will need sudo access in orde
 $ pwd
 /usr/local/bin
 $ sudo vi nita-cmd_hello
-[sudo] password for jcluser: 
+[sudo] password for jcluser:
 $ cat nita-cmd_hello
 #!/bin/bash
 if [ "$_CLI_RUNNER_DEBUG" == 1 ]; then
@@ -83,7 +96,7 @@ fi
 # This is the actual command that you want to wrap with the cli...
 echo "Hello World!" >&1
 $ sudo chmod +x nita-cmd_hello
-$ 
+$
 ```
 Add inline debugging by setting the environment variable ``_CLI_RUNNER_DEBUG`` in the parent shell, like this:
 ```shell
@@ -100,7 +113,7 @@ At the same time as you create a new command, you should also add a correspondin
 $ pwd
 /usr/local/bin
 $ sudo vi nita-cmd_hello_help
-[sudo] password for jcluser: 
+[sudo] password for jcluser:
 $ cat nita-cmd_hello_help
 #!/bin/bash
 echo -n "    nita-cmd hello => "
@@ -138,8 +151,8 @@ And if you press &lt;tab&gt; again...
 
 ```shell
 $ nita-cmd jenkins <tab>
-backup   down     jobs     logs     ports    restore  start    stop     version  whoami   
-cli      ips      labels   plugins  restart  set      status   up       volumes 
+backup   down     jobs     logs     ports    restore  start    stop     version  whoami
+cli      ips      labels   plugins  restart  set      status   up       volumes
 ```
 You get the idea.
 
@@ -150,7 +163,7 @@ To see which version of NITA you are running, type the command ``nita-cmd cli ve
 ```shell
 $ nita-cmd cli version
 nita-cli 22.8
-$ 
+$
 ```
 
 # SEE ALSO

--- a/openspec/changes/add-kube-renew-certs-command/.openspec.yaml
+++ b/openspec/changes/add-kube-renew-certs-command/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-23

--- a/openspec/changes/add-kube-renew-certs-command/design.md
+++ b/openspec/changes/add-kube-renew-certs-command/design.md
@@ -1,0 +1,74 @@
+## Context
+
+`nita-cmd` maps sub-commands to executable scripts, and existing Kubernetes
+helpers in `cli_scripts/` follow a common pattern:
+- detect required binaries using `command -v`
+- set command text in `CMD`
+- print debug command when `_CLI_RUNNER_DEBUG` is set
+- execute via `eval "${CMD}"`
+
+The requested feature adds `nita-cmd kube renew-certs` while keeping this
+execution model and help-script convention.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a new `kube renew-certs` command following existing script conventions.
+- Provide explicit help output through a paired `_help` script.
+- Make failure modes explicit when certificate renewal binaries are missing.
+
+**Non-Goals:**
+- Re-architecting `nita-cmd` dispatch logic.
+- Automatically restarting control-plane components beyond what the renewal
+  command itself requires.
+- Implementing certificate expiry monitoring/alerting.
+
+## Decisions
+
+### Decision 1: Implement as standalone script pair
+
+**Choice:** Create `nita-cmd_kube_renew-certs` and
+`nita-cmd_kube_renew-certs_help` in `cli_scripts/`.
+
+**Rationale:** This matches the current extension mechanism and keeps command
+registration zero-touch for the dispatcher.
+
+### Decision 2: Prefer `kubeadm certs renew all` when available
+
+**Choice:** Use `kubeadm certs renew all` as the primary renewal action.
+
+**Rationale:** `kubeadm` is the standard certificate lifecycle interface for
+kubeadm-managed clusters and provides a single command for renewing all control
+plane certificates.
+
+**Alternatives considered:**
+- `kubectl certificate approve` flow only: handles CSRs but does not renew all
+  control-plane certificates.
+- Custom per-certificate renewal scripts: higher maintenance burden and less
+  portability.
+
+### Decision 3: Fail fast with actionable error when unsupported
+
+**Choice:** If required binaries are unavailable, print a clear unsupported
+message and exit non-zero.
+
+**Rationale:** Existing scripts already perform binary detection; this preserves
+predictable behavior and avoids partial/no-op execution.
+
+## Risks / Trade-offs
+
+- **Environment mismatch**: clusters not provisioned with kubeadm may not
+  support `kubeadm certs renew all`.
+- **Privileges**: renewal typically requires elevated privileges; invocation may
+  fail without proper permissions.
+- **Operational follow-up**: some environments require control-plane component
+  restarts after renewal; this command should document, not automate, that
+  workflow.
+
+## Migration Plan
+
+1. Add the new command and help scripts in `cli_scripts/`.
+2. Update `docs/nita-cmd.md` command reference with usage and caveats.
+3. Validate output in both normal and `_CLI_RUNNER_DEBUG=1` modes.
+4. Run the command in an environment with and without `kubeadm` to validate
+   success and failure messaging.

--- a/openspec/changes/add-kube-renew-certs-command/proposal.md
+++ b/openspec/changes/add-kube-renew-certs-command/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+Kubernetes certificate expiration can cause disruptive control-plane or node
+authentication failures. NITA already provides `nita-cmd kube` operational
+helpers, but it does not provide a guided command for certificate renewal.
+Adding `nita-cmd kube renew-certs` gives operators a single, documented entry
+point for this maintenance task and keeps command behavior consistent with the
+existing `cli_scripts` model.
+
+## What Changes
+
+- **New** `cli_scripts/nita-cmd_kube_renew-certs`: Adds the
+  `nita-cmd kube renew-certs` sub-command.
+- **New** `cli_scripts/nita-cmd_kube_renew-certs_help`: Adds help text for the
+  new sub-command.
+- **Modified** `docs/nita-cmd.md`: Documents the new command and expected
+  behavior.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `cli`: Add a Kubernetes certificate renewal sub-command under
+  `nita-cmd kube`.
+
+## Impact
+
+- CLI scripts: two new scripts in `cli_scripts/`
+- Documentation: one update in `docs/nita-cmd.md`
+- Runtime dependency: the command path relies on `kubeadm` availability for
+  direct certificate renewal, and should fail with a clear message when
+  unsupported

--- a/openspec/changes/add-kube-renew-certs-command/specs/cli/spec.md
+++ b/openspec/changes/add-kube-renew-certs-command/specs/cli/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Kubernetes Certificate Renewal Command
+The system SHALL provide `nita-cmd kube renew-certs` as a dedicated
+sub-command for Kubernetes certificate renewal operations.
+
+#### Scenario: Command is discoverable via help
+- **GIVEN** the CLI scripts are installed
+- **WHEN** `nita-cmd kube help` is run
+- **THEN** an entry for `nita-cmd kube renew-certs` is listed with a one-line
+  description
+
+#### Scenario: Renewal command executes on supported environments
+- **GIVEN** a host where `kubeadm` is available and the user has required
+  privileges
+- **WHEN** `nita-cmd kube renew-certs` is run
+- **THEN** the command executes `kubeadm certs renew all`
+- **AND** exits with code 0 when renewal succeeds
+
+#### Scenario: Clear failure on unsupported environments
+- **GIVEN** a host where `kubeadm` is not available
+- **WHEN** `nita-cmd kube renew-certs` is run
+- **THEN** the command prints an actionable unsupported-environment message
+- **AND** exits with a non-zero status
+
+#### Scenario: Debug output shows wrapped command
+- **GIVEN** `_CLI_RUNNER_DEBUG=1` is set
+- **WHEN** `nita-cmd kube renew-certs` is run
+- **THEN** the underlying shell command is printed to stderr before execution

--- a/openspec/changes/add-kube-renew-certs-command/tasks.md
+++ b/openspec/changes/add-kube-renew-certs-command/tasks.md
@@ -1,0 +1,29 @@
+## 1. CLI Script
+
+- [x] 1.1 Add `cli_scripts/nita-cmd_kube_renew-certs` with project header and
+      the same command-selection/debug pattern used by existing kube scripts
+- [x] 1.2 Implement primary command execution for certificate renewal via
+      `kubeadm certs renew all` when available
+- [x] 1.3 Return a clear non-zero error and message when certificate renewal is
+      unsupported in the current environment
+
+## 2. Help Script
+
+- [x] 2.1 Add `cli_scripts/nita-cmd_kube_renew-certs_help` with one-line usage
+      text consistent with existing `_help` scripts
+
+## 3. Documentation
+
+- [x] 3.1 Update `docs/nita-cmd.md` to include `nita-cmd kube renew-certs`
+- [x] 3.2 Document prerequisites and operational caveats (permissions,
+      kubeadm-managed clusters, post-renewal restart expectations)
+
+## 4. Verification
+
+- [ ] 4.1 Confirm the new command appears in `nita-cmd kube help`
+- [ ] 4.2 Run `nita-cmd kube renew-certs` where `kubeadm` exists and confirm
+      renewal command execution
+- [ ] 4.3 Run `nita-cmd kube renew-certs` where `kubeadm` is absent and confirm
+      expected error behavior and non-zero exit code
+- [ ] 4.4 Run with `_CLI_RUNNER_DEBUG=1` and confirm the underlying command is
+      printed to stderr before execution


### PR DESCRIPTION
certificate renewal

- Introduced `nita-cmd kube renew-certs` to facilitate Kubernetes certificate renewal.
- Implemented command execution via `kubeadm certs renew all` and restart of `kubelet`.
- Added help script for the new command and updated documentation accordingly.
- Ensured clear error messaging for unsupported environments.