### PR TITLE
Fix Ubuntu OpenJDK install and ConfigMap ordering

### DIFF
--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -26,9 +26,9 @@ Name: git
 URL: https://git-scm.com/
 License: https://git-scm.com/about/free-and-open-source
 
-Name: openjdk-19-jre-headless
-URL: https://packages.ubuntu.com/jammy/openjdk-19-jre-headless
-License: https://changelogs.ubuntu.com/changelogs/pool/universe/o/openjdk-19/openjdk-19_19.0.2+7-0ubuntu3~22.04/copyright
+Name: openjdk-21-jre-headless
+URL: https://packages.ubuntu.com/jammy/openjdk-21-jre-headless
+License: https://changelogs.ubuntu.com/changelogs/pool/universe/o/openjdk-21/openjdk-21_21.0.11+10-1~22.04.2/copyright
 
 Name: socat
 URL: http://www.dest-unreach.org/socat/

--- a/install.sh
+++ b/install.sh
@@ -403,10 +403,8 @@ Question "Install NITA repositories" && {
 
     cd  ${K8SROOT}
 
-    echo "${ME}: Applying base Kubernetes resources"
-    for f in nita-namespace.yaml storageClass.yaml pv.yaml pv2.yaml mariadb-persistentvolumeclaim.yaml jenkins-home-persistentvolumeclaim.yaml service-account.yaml cluster-role.yaml role-binding.yaml; do
-        kubectl apply -f ${f} || exit 1
-    done
+    echo "${ME}: Applying NITA namespace"
+    kubectl apply -f nita-namespace.yaml || exit 1
 
     mkdir -p ${PROXY}
     wget --inet4-only https://raw.githubusercontent.com/${GITHUB_ORG}/nita-webapp/main/nginx/nginx.conf -O ${PROXY}/nginx.conf

--- a/install.sh
+++ b/install.sh
@@ -27,7 +27,7 @@ NITAROOT=${NITAROOT:=/opt}              # Where to install NITA
 NITAPROJECT=${NITAPROJECT:=/var/nita_project}    # Home of NITA project files
 BINDIR=${BINDIR:=/usr/local/bin}        # Where to put binaries
 BASH_COMPLETION=${BASH_COMPLETION:="/etc/bash_completion.d"}
-JAVA_HOME=${JAVA_HOME:=$NITAROOT/jdk-19.0.1}
+JAVA_HOME=${JAVA_HOME:=}
 
 K8SROOT=${K8SROOT:=$NITAROOT/nita/k8s}
 PROXY=${PROXY:=$K8SROOT/proxy}
@@ -43,7 +43,7 @@ KEYPASS=${KEYPASS:="nita123"}
 KUBEROOT=${KUBEROOT:=/etc/kubernetes}
 KUBECONFIG=${KUBECONFIG:=$KUBEROOT/admin.conf}
 
-PATH=${PATH}:${JAVA_HOME}/bin
+[ -n "${JAVA_HOME}" ] && PATH=${PATH}:${JAVA_HOME}/bin
 export OWNER_HOME=`egrep "^${REALUSER}" /etc/passwd | awk -F: '{print $6}'`
 export PATH NITAROOT KUBEROOT K8SROOT PROXY CERTS JENKINS JUNOS_MCP_DEVICES JUNOS_MCP_REPO JUNOS_MCP_IMAGE JUNOS_MCP_IMAGE_ARCHIVE JUNOS_MCP_TOKEN_ID JUNOS_MCP_TOKEN_VALUE KEYPASS KUBECONFIG JAVA_HOME CONTAINER_REGISTRY GITHUB_ORG NITA_ANSIBLE_IMAGE NITA_ROBOT_IMAGE
 
@@ -175,6 +175,7 @@ Question "Install system dependencies" && {
 
     eval "${UPDATE}"
     eval "${INSTALLER} ca-certificates curl wget gnupg gnupg2"
+    mkdir -p /usr/share/keyrings
 
     [ "X${OS}" = "XAlmaLinux" ] && {
 
@@ -189,6 +190,9 @@ Question "Install system dependencies" && {
             tar xf openjdk-19.0.1_linux-x64_bin.tar.gz
             mv jdk-19.0.1 ${NITAROOT}
             rm -f openjdk-19.0.1_linux-x64_bin.tar.gz
+            JAVA_HOME=${NITAROOT}/jdk-19.0.1
+            PATH=${PATH}:${JAVA_HOME}/bin
+            export JAVA_HOME PATH
 
             tee /etc/profile.d/jdk19.sh <<-EOF1
 export JAVA_HOME=${NITAROOT}/jdk-19.0.1
@@ -201,8 +205,6 @@ EOF1
             echo "${ME}: Cool, you already have keytool installed"
         fi
 
-        java -version
-
     }
 
     [ "X${OS}" = "XUbuntu" ] && {
@@ -211,11 +213,12 @@ EOF1
         eval "${INSTALLER} software-properties-common apt-transport-https"
         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list
-        eval "${INSTALLER} openjdk-19-jre-headless"
+        eval "${INSTALLER} openjdk-21-jre-headless"
 
     }
 
-    mkdir -p /usr/share/keyrings
+    Verify keytool
+    java -version
 
     eval "${UPDATE}"
 
@@ -399,9 +402,13 @@ Question "Install NITA repositories" && {
     mkdir -p ${NITAPROJECT}
 
     cd  ${K8SROOT}
-    bash apply-k8s.sh
 
-    mkdir -p ${NITAROOT}/nita/k8s/proxy
+    echo "${ME}: Applying base Kubernetes resources"
+    for f in nita-namespace.yaml storageClass.yaml pv.yaml pv2.yaml mariadb-persistentvolumeclaim.yaml jenkins-home-persistentvolumeclaim.yaml service-account.yaml cluster-role.yaml role-binding.yaml; do
+        kubectl apply -f ${f} || exit 1
+    done
+
+    mkdir -p ${PROXY}
     wget --inet4-only https://raw.githubusercontent.com/${GITHUB_ORG}/nita-webapp/main/nginx/nginx.conf -O ${PROXY}/nginx.conf
     # ln -s ${NITAROOT}/nita/k8s/proxy ${PROXY}/nginx.conf
 
@@ -413,8 +420,8 @@ Question "Install NITA repositories" && {
     openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout ${CERTS}/nginx-certificate-key.key -out ${CERTS}/nginx-certificate.crt
 
     echo "${ME}: Creating config maps for proxy pod"
-    kubectl create cm proxy-config-cm --from-file=${PROXY}/nginx.conf --namespace nita
-    kubectl create cm proxy-cert-cm --from-file=${CERTS}/ --namespace nita
+    kubectl create cm proxy-config-cm --from-file=${PROXY}/nginx.conf --namespace nita --dry-run=client -o yaml | kubectl apply -f -
+    kubectl create cm proxy-cert-cm --from-file=${CERTS}/ --namespace nita --dry-run=client -o yaml | kubectl apply -f -
 
     echo "${ME}: Generating Jenkins keystore."
     Debug "echo In ${JENKINS}"
@@ -429,8 +436,11 @@ Question "Install NITA repositories" && {
     openssl pkcs12 -in ${JENKINS}/jenkins.p12 -nokeys -out ${JENKINS}/jenkins.crt -password pass:${KEYPASS}
 
     echo "${ME}: Creating config maps for Jenkins pod"
-    kubectl create cm jenkins-crt --from-file=${JENKINS}/jenkins.crt --namespace nita
-    kubectl create cm jenkins-keystore --from-file=${JENKINS}/jenkins_keystore.jks --namespace nita
+    kubectl create cm jenkins-crt --from-file=${JENKINS}/jenkins.crt --namespace nita --dry-run=client -o yaml | kubectl apply -f -
+    kubectl create cm jenkins-keystore --from-file=${JENKINS}/jenkins_keystore.jks --namespace nita --dry-run=client -o yaml | kubectl apply -f -
+
+    echo "${ME}: Applying NITA Kubernetes workloads"
+    bash apply-k8s.sh || exit 1
 
     echo "${ME}: Please wait ${bold}5-10 minutes${normal} for the Kubernetes pods to initialise"
 

--- a/k8s/apply-k8s.sh
+++ b/k8s/apply-k8s.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 CONTAINER_REGISTRY=${CONTAINER_REGISTRY:=ghcr.io/aburston}
 export CONTAINER_REGISTRY
 
@@ -21,8 +23,30 @@ echo "Please be sure you are in the same folder as the yaml files"
 echo "Using container registry: ${CONTAINER_REGISTRY}"
 echo "Using CSRF trusted origins: ${CSRF_TRUSTED_ORIGINS}"
 
-FILES="nita-namespace.yaml pv.yaml pv2.yaml mariadb-persistentvolumeclaim.yaml jenkins-home-persistentvolumeclaim.yaml cluster-role.yaml db-deployment.yaml db-service.yaml jenkins-deployment.yaml jenkins-service.yaml proxy-deployment.yaml role-binding.yaml service-account.yaml storageClass.yaml webapp-deployment.yaml webapp-service.yaml junos-mcp-deployment.yaml junos-mcp-service.yaml"
+BASE_FILES="nita-namespace.yaml storageClass.yaml pv.yaml pv2.yaml mariadb-persistentvolumeclaim.yaml jenkins-home-persistentvolumeclaim.yaml service-account.yaml cluster-role.yaml role-binding.yaml"
+WORKLOAD_FILES="db-service.yaml db-deployment.yaml webapp-service.yaml webapp-deployment.yaml jenkins-service.yaml jenkins-deployment.yaml proxy-deployment.yaml"
+FILES="${BASE_FILES} ${WORKLOAD_FILES}"
+REQUIRED_CONFIGMAPS="proxy-config-cm proxy-cert-cm jenkins-crt jenkins-keystore"
 
-for f in ${FILES}; do
-    envsubst '${CONTAINER_REGISTRY} ${CSRF_TRUSTED_ORIGINS}' < ${f} | kubectl apply -f -
+ApplyYaml() {
+    envsubst '${CONTAINER_REGISTRY} ${CSRF_TRUSTED_ORIGINS}' < "$1" | kubectl apply -f -
+}
+
+for f in ${BASE_FILES}; do
+    ApplyYaml "${f}"
+done
+
+missing=0
+for cm in ${REQUIRED_CONFIGMAPS}; do
+    if ! kubectl get cm "${cm}" --namespace nita >/dev/null 2>&1; then
+        echo "Error: required ConfigMap \"${cm}\" is missing in namespace nita." >&2
+        echo "Create the proxy and Jenkins ConfigMaps before applying workloads." >&2
+        missing=1
+    fi
+done
+
+[ "${missing}" -eq 0 ] || exit 1
+
+for f in ${WORKLOAD_FILES}; do
+    ApplyYaml "${f}"
 done

--- a/k8s/apply-k8s.sh
+++ b/k8s/apply-k8s.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 CONTAINER_REGISTRY=${CONTAINER_REGISTRY:=ghcr.io/aburston}
 export CONTAINER_REGISTRY
 
@@ -11,12 +9,14 @@ if [[ -z "${CSRF_TRUSTED_ORIGINS:-}" ]]; then
     _origins="https://localhost,http://localhost"
     _host=$(hostname 2>/dev/null || true)
     [[ -n "$_host" ]] && _origins="https://${_host},http://${_host},${_origins}"
-    for _ip in $(hostname -I 2>/dev/null); do
+    for _ip in $(hostname -I 2>/dev/null || true); do
         _origins="https://${_ip},http://${_ip},${_origins}"
     done
     CSRF_TRUSTED_ORIGINS="${_origins}"
 fi
 export CSRF_TRUSTED_ORIGINS
+
+set -e
 
 echo "Applying k8s YAML file to setup necessary pods!!!"
 echo "Please be sure you are in the same folder as the yaml files"
@@ -25,7 +25,6 @@ echo "Using CSRF trusted origins: ${CSRF_TRUSTED_ORIGINS}"
 
 BASE_FILES="nita-namespace.yaml storageClass.yaml pv.yaml pv2.yaml mariadb-persistentvolumeclaim.yaml jenkins-home-persistentvolumeclaim.yaml service-account.yaml cluster-role.yaml role-binding.yaml"
 WORKLOAD_FILES="db-service.yaml db-deployment.yaml webapp-service.yaml webapp-deployment.yaml jenkins-service.yaml jenkins-deployment.yaml proxy-deployment.yaml"
-FILES="${BASE_FILES} ${WORKLOAD_FILES}"
 REQUIRED_CONFIGMAPS="proxy-config-cm proxy-cert-cm jenkins-crt jenkins-keystore"
 
 ApplyYaml() {

--- a/tests/test_installer_regression.py
+++ b/tests/test_installer_regression.py
@@ -18,10 +18,9 @@ class InstallerRegressionTests(unittest.TestCase):
         self.assertNotIn("openjdk-19-jre-headless", self.install_text)
 
     def test_jdk_19_java_home_is_not_global_default(self):
-        self.assertNotRegex(
+        self.assertNotIn(
+            "JAVA_HOME=${JAVA_HOME:=$NITAROOT/jdk-19.0.1}",
             self.install_text,
-            r"^JAVA_HOME=\$\{JAVA_HOME:=\$NITAROOT/jdk-19\.0\.1\}",
-            msg="AlmaLinux tarball JAVA_HOME must not be the global default",
         )
 
     def test_core_configmaps_are_created_before_core_apply(self):
@@ -40,11 +39,19 @@ class InstallerRegressionTests(unittest.TestCase):
             )
 
     def test_core_apply_excludes_optional_junos_mcp_manifests(self):
-        files_match = re.search(r'^FILES="([^"]+)"', self.apply_text, re.MULTILINE)
-        self.assertIsNotNone(files_match, "apply-k8s.sh should define FILES")
-        files = files_match.group(1).split()
-        self.assertNotIn("junos-mcp-deployment.yaml", files)
-        self.assertNotIn("junos-mcp-service.yaml", files)
+        for variable in ("BASE_FILES", "WORKLOAD_FILES"):
+            files_match = re.search(
+                rf'^{variable}="([^"]+)"',
+                self.apply_text,
+                re.MULTILINE,
+            )
+            self.assertIsNotNone(
+                files_match,
+                f"apply-k8s.sh should define {variable}",
+            )
+            files = files_match.group(1).split()
+            self.assertNotIn("junos-mcp-deployment.yaml", files)
+            self.assertNotIn("junos-mcp-service.yaml", files)
 
     def test_core_apply_preflights_required_configmaps(self):
         for name in (

--- a/tests/test_installer_regression.py
+++ b/tests/test_installer_regression.py
@@ -1,0 +1,61 @@
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALL_SH = ROOT / "install.sh"
+APPLY_K8S_SH = ROOT / "k8s" / "apply-k8s.sh"
+
+
+class InstallerRegressionTests(unittest.TestCase):
+    def setUp(self):
+        self.install_text = INSTALL_SH.read_text(encoding="utf-8")
+        self.apply_text = APPLY_K8S_SH.read_text(encoding="utf-8")
+
+    def test_ubuntu_installs_supported_openjdk_package(self):
+        self.assertIn("openjdk-21-jre-headless", self.install_text)
+        self.assertNotIn("openjdk-19-jre-headless", self.install_text)
+
+    def test_jdk_19_java_home_is_not_global_default(self):
+        self.assertNotRegex(
+            self.install_text,
+            r"^JAVA_HOME=\$\{JAVA_HOME:=\$NITAROOT/jdk-19\.0\.1\}",
+            msg="AlmaLinux tarball JAVA_HOME must not be the global default",
+        )
+
+    def test_core_configmaps_are_created_before_core_apply(self):
+        apply_pos = self.install_text.index("bash apply-k8s.sh")
+        for name in (
+            "proxy-config-cm",
+            "proxy-cert-cm",
+            "jenkins-crt",
+            "jenkins-keystore",
+        ):
+            create_pos = self.install_text.index(f"kubectl create cm {name}")
+            self.assertLess(
+                create_pos,
+                apply_pos,
+                msg=f"{name} must exist before deployments are applied",
+            )
+
+    def test_core_apply_excludes_optional_junos_mcp_manifests(self):
+        files_match = re.search(r'^FILES="([^"]+)"', self.apply_text, re.MULTILINE)
+        self.assertIsNotNone(files_match, "apply-k8s.sh should define FILES")
+        files = files_match.group(1).split()
+        self.assertNotIn("junos-mcp-deployment.yaml", files)
+        self.assertNotIn("junos-mcp-service.yaml", files)
+
+    def test_core_apply_preflights_required_configmaps(self):
+        for name in (
+            "proxy-config-cm",
+            "proxy-cert-cm",
+            "jenkins-crt",
+            "jenkins-keystore",
+        ):
+            self.assertIn(name, self.apply_text)
+        self.assertRegex(self.apply_text, r"kubectl get cm .*\$\{cm\}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- replace Ubuntu's removed `openjdk-19-jre-headless` installer dependency with `openjdk-21-jre-headless`
- remove the global `JAVA_HOME=/opt/jdk-19.0.1` default while preserving the existing AlmaLinux fallback path
- create proxy/Jenkins ConfigMaps before applying workloads, and add a core apply preflight for those ConfigMaps
- keep optional Junos MCP manifests out of the core `apply-k8s.sh` flow
- add installer regression tests for the OpenJDK and ConfigMap ordering behavior

Fixes #55.

## Relationship to #44
This may also address the missing-ConfigMap failure mode described in #44. The installer previously applied Jenkins/proxy workloads before creating the `jenkins-crt`, `jenkins-keystore`, `proxy-config-cm`, and `proxy-cert-cm` ConfigMaps that those workloads mount.

I am not marking #44 as fixed here because I did not reproduce the original report in its exact environment: Ubuntu 24.04, k3s v1.32.3+k3s1, and the older Jenkins image/tag class from the issue. The validation here proves the corrected ordering prevents missing core ConfigMap mount events in an isolated Kind cluster, but fully closing #44 would require an isolated k3s reproduction that fails on the old flow and passes with this branch.

## Validation
- `python3 -m unittest discover -s tests -p 'test_installer*.py'`
- `bash -n install.sh k8s/apply-k8s.sh .github/scripts/setup-configmaps.sh`
- `git diff --check`
- Docker package checks for Ubuntu 22.04 and 24.04 confirmed OpenJDK 21 is available and OpenJDK 19 is unavailable/removed
- isolated Kind validation with a temp `KUBECONFIG` and unique cluster; Jenkins and proxy reached `Running`, and no missing `jenkins-crt`, `jenkins-keystore`, `proxy-config-cm`, or `proxy-cert-cm` mount events appeared

## Notes
The local isolated Kind validation ran on an arm64 Docker/Kubernetes environment, not x86_64.
